### PR TITLE
Fix: add defensiveness

### DIFF
--- a/lib/googleadwords.js
+++ b/lib/googleadwords.js
@@ -187,7 +187,7 @@ var GoogleAdwords = function (spec, my) {
     bodyArray.shift()
     _finalObj.total = bodyArray[bodyArray.length - 1].split('\t')[1]
     bodyArray.pop()
-    var columnNames = bodyArray[0].split('\t')
+    var columnNames = bodyArray[0] ? bodyArray[0] : bodyArray[0].split('\t')
     _finalObj.fieldLength = columnNames.length
     bodyArray.shift()
     _finalObj.data = _.map(bodyArray, function (row) {


### PR DESCRIPTION
We're seeing this error in prod:

```
TypeError /app/node_modules/google-adwords-reports/lib/googleadwords.js:188
Cannot read property 'split' of undefined
```

This should fix things.